### PR TITLE
ESPHome 2025.8.0 requires libraries to have a name, so add a name

### DIFF
--- a/m5stack-papers3.yaml
+++ b/m5stack-papers3.yaml
@@ -5,7 +5,7 @@ esphome:
   platformio_options:
     build_flags: "-DBOARD_HAS_PSRAM"
   libraries:
-    - https://github.com/patrick3399/epdiy
+    - EPDIY=https://github.com/patrick3399/epdiy
   on_boot:
     then:
       - rtttl.play: 'siren:d=8,o=5,b=100:d,e,d,e,d,e,d,e'


### PR DESCRIPTION
Thanks for the work here, this is now not compiling on the latest esphome, there was a breaking change which required a name, this very boring PR adds a name.

(There are other issues with i2c which from a quick search seems to be an Espressif ESP 3.2.0 https://forum.arduino.cc/t/conflict-driver-ng-i2c-driver/1399382 ) which I just commented out the relevant sensors for now, but the name seems essential )