### PR TITLE
Add GitHub Actions CI for ESPHome validation/compile and Codespaces config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "ESPHome Components Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "containerEnv": {
+    "ESPHOME_VERSION": "2026.1.0"
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install esphome==${ESPHOME_VERSION}",
+  "remoteUser": "vscode"
+}

--- a/.github/workflows/esphome-ci.yml
+++ b/.github/workflows/esphome-ci.yml
@@ -1,0 +1,48 @@
+name: ESPHome Components CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      esphome_version:
+        description: ESPHome version to use
+        required: false
+        default: "2026.1.0"
+
+jobs:
+  validate-and-build:
+    name: Validate and Compile (${{ matrix.config }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - m5stack-stamplc.yaml
+          - m5stack-papers3.yaml
+
+    env:
+      ESPHOME_VERSION: ${{ github.event.inputs.esphome_version || '2026.1.0' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install ESPHome
+        run: |
+          python -m pip install --upgrade pip
+          pip install "esphome==${ESPHOME_VERSION}"
+
+      - name: Validate configuration
+        run: esphome config "${{ matrix.config }}"
+
+      - name: Compile firmware
+        run: esphome compile "${{ matrix.config }}"


### PR DESCRIPTION
### Motivation
- 在 repo 中加入可自訂 ESPHome 版本的 CI，以自動化驗證並編譯現有 ESPHome 元件與範例設定，預設使用 `2026.1.0`。 
- 提供一個一致的開發環境（Codespaces / devcontainer）以便開發者快速上手並在相同版本下重現問題。

### Description
- 新增 GitHub Actions 工作流程 ` .github/workflows/esphome-ci.yml`，支援 `push` / `pull_request` / `workflow_dispatch` 並提供 `esphome_version` 輸入（預設 `2026.1.0`）。
- CI 使用 matrix 針對 `m5stack-stamplc.yaml` 和 `m5stack-papers3.yaml` 逐一執行 `esphome config` 與 `esphome compile`，並在步驟中以 `actions/setup-python@v5` 設定 Python 3.11 並安裝 `esphome==${ESPHOME_VERSION}`。
- 新增 Codespaces / devcontainer 設定檔 ` .devcontainer/devcontainer.json`，以 `mcr.microsoft.com/devcontainers/python:1-3.11-bullseye` 映像為基底，設定 `ESPHOME_VERSION` 環境變數並在 `postCreateCommand` 安裝對應版本的 `esphome`。
- 已將兩個檔案加入版本控制並建立對應 PR（含工作流程與 devcontainer 檔案）。

### Testing
- 已在此環境以 `python -m pip install --upgrade pip && pip install esphome==2026.1.0` 成功安裝 `esphome==2026.1.0`（安裝成功）。
- 執行 `esphome config m5stack-stamplc.yaml` 失敗，因為現有元件 `components/pi4ioe5v6408/__init__.py` 中呼叫 `gpio_base_schema(..., invertable=...)` 與 ESPHome API 不相容，導致 `TypeError`（測試失敗）。
- 執行 `esphome config m5stack-papers3.yaml` 無法完成，因環境網路/代理限制導致外部 Google Fonts 下載失敗（解析到字型下載階段遭遇網路錯誤，測試未通過）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995cb165034832688322175e060be86)