### PR TITLE
Enhance ESPHome CI/CD pipeline with artifact uploads and caching

### DIFF
--- a/.github/workflows/esphome-ci.yml
+++ b/.github/workflows/esphome-ci.yml
@@ -20,9 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - m5stack-stamplc.yaml
-          - m5stack-papers3.yaml
+        include:
+          - config: m5stack-stamplc.yaml
+            artifact: firmware-stamplc
+            build_path: /config/esphome/m5plcbuild
+          - config: m5stack-papers3.yaml
+            artifact: firmware-papers3
+            build_path: /config/esphome/m5papers3
 
     env:
       ESPHOME_VERSION: ${{ github.event.inputs.esphome_version || '2026.1.0' }}
@@ -35,14 +39,46 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install ESPHome
         run: |
           python -m pip install --upgrade pip
           pip install "esphome==${ESPHOME_VERSION}"
 
+      - name: Create dummy secrets.yaml for CI
+        run: |
+          cat > secrets.yaml << 'EOF'
+          wifi_ssid: "CI_DUMMY_SSID"
+          wifi_password: "CI_DUMMY_PASSWORD"
+          api_key: "0000000000000000000000000000000000000000000000000000000000000000"
+          ota_password: "CI_DUMMY_OTA"
+          EOF
+
+      - name: Create build directory
+        run: |
+          sudo mkdir -p "${{ matrix.build_path }}"
+          sudo chmod 777 "${{ matrix.build_path }}"
+
+      - name: Cache PlatformIO toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: platformio-${{ runner.os }}-${{ matrix.config }}-${{ env.ESPHOME_VERSION }}
+          restore-keys: |
+            platformio-${{ runner.os }}-${{ matrix.config }}-
+            platformio-${{ runner.os }}-
+
       - name: Validate configuration
         run: esphome config "${{ matrix.config }}"
 
       - name: Compile firmware
         run: esphome compile "${{ matrix.config }}"
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.build_path }}/.esphome/build/*/firmware*.bin
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# ESPHome secrets - never commit real credentials
+secrets.yaml
+
+# ESPHome build output
+.esphome/
+build/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+
+# VS Code
+.vscode/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
This PR improves the ESPHome GitHub Actions CI/CD workflow by adding build artifact uploads, PlatformIO toolchain caching, and necessary CI infrastructure setup. It also adds a `.gitignore` file to prevent accidental commits of sensitive credentials and build artifacts.

## Key Changes

**Workflow Improvements:**
- Refactored matrix strategy from simple `config` list to `include` format to support per-device configuration metadata
- Added device-specific artifact names and build paths for each ESPHome configuration
- Implemented PlatformIO toolchain caching to speed up subsequent builds
- Added Python pip caching to reduce dependency installation time
- Created dummy `secrets.yaml` during CI runs to satisfy ESPHome's configuration requirements
- Added build directory creation with proper permissions for CI environment
- Implemented firmware artifact upload with 30-day retention policy

**Repository Configuration:**
- Added `.gitignore` to prevent accidental commits of:
  - Real credentials in `secrets.yaml`
  - ESPHome build artifacts (`.esphome/`, `build/`)
  - Python virtual environments and cache files
  - IDE and OS-specific files

## Implementation Details
- The matrix now includes per-device `artifact` and `build_path` variables, enabling proper organization of build outputs
- Dummy secrets are created with placeholder values to allow configuration validation without exposing real credentials
- PlatformIO cache key includes both the config file and ESPHome version for cache invalidation when either changes
- Firmware artifacts are uploaded with a warning-level fallback if no binaries are found, preventing workflow failures on edge cases

https://claude.ai/code/session_01VkL91J97bJg7qnm5ziSWQ6