### PR TITLE
fix(bmi270): rewrite using ESPHome native I2C, remove Bosch SDK dependency

### DIFF
--- a/components/bmi270/bmi270.cpp
+++ b/components/bmi270/bmi270.cpp
@@ -1,98 +1,149 @@
 #include "bmi270.h"
+#include "bmi270_config.h"
 #include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include <algorithm>
+#include <cstring>
 
 namespace esphome {
 namespace bmi270 {
 
 static const char *const TAG = "bmi270";
 
+static const uint8_t REG_CHIP_ID        = 0x00;
+static const uint8_t REG_INTERNAL_STATUS = 0x21;
+static const uint8_t REG_ACC_DATA       = 0x0C;
+static const uint8_t REG_TEMP_DATA      = 0x22;
+static const uint8_t REG_ACC_CONF       = 0x40;
+static const uint8_t REG_ACC_RANGE      = 0x41;
+static const uint8_t REG_GYR_CONF       = 0x42;
+static const uint8_t REG_GYR_RANGE      = 0x43;
+static const uint8_t REG_INIT_CTRL      = 0x59;
+static const uint8_t REG_INIT_ADDR_0    = 0x5B;
+static const uint8_t REG_INIT_ADDR_1    = 0x5C;
+static const uint8_t REG_INIT_DATA      = 0x5E;
+static const uint8_t REG_PWR_CONF       = 0x7C;
+static const uint8_t REG_PWR_CTRL       = 0x7D;
+static const uint8_t REG_CMD            = 0x7E;
+
+static const uint8_t CHIP_ID            = 0x24;
+static const uint8_t CMD_SOFT_RESET     = 0xB6;
+
 void BMI270Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up BMI270...");
-  this->i2c_dev_ = make_unique<esphome::i2c::I2CDevice>(this->i2c_bus_, this->address_);
-  this->i2c_dev_->set_timeout(50);
 
-  this->sensor_.intf_ptr = this->i2c_dev_.get();
-  this->sensor_.intf = BMI2_I2C_INTF;
-  this->sensor_.read = read_bytes;
-  this->sensor_.write = write_bytes;
-  this->sensor_.delay_us = delay_usec;
+  uint8_t val = CMD_SOFT_RESET;
+  this->write_register(REG_CMD, &val, 1);
+  delay(100);
 
-  int8_t rslt;
-
-  // Initialize the BMI270
-  rslt = bmi270_init(&this->sensor_);
-  if (rslt != BMI2_OK) {
-    ESP_LOGE(TAG, "BMI270 initialization failed: %d", rslt);
+  uint8_t chip_id = 0;
+  if (this->read_register(REG_CHIP_ID, &chip_id, 1) != i2c::ERROR_OK || chip_id != CHIP_ID) {
+    ESP_LOGE(TAG, "Unexpected chip ID: 0x%02X (expected 0x%02X)", chip_id, CHIP_ID);
     this->mark_failed();
     return;
   }
 
-  ESP_LOGI(TAG, "BMI270 initialization succeeded");
-
-  // Enable accelerometer and gyroscope
-  uint8_t sens_list[2] = { BMI2_ACCEL, BMI2_GYRO };
-  rslt = bmi270_sensor_enable(sens_list, 2, &this->sensor_);
-  if (rslt != BMI2_OK) {
-    ESP_LOGE(TAG, "Failed to enable accelerometer and gyroscope: %d", rslt);
+  if (!this->bmi270_init_config_file()) {
+    ESP_LOGE(TAG, "Failed to load BMI270 config file");
     this->mark_failed();
     return;
   }
 
-  // Configure accelerometer
-  this->accel_cfg_.odr = BMI2_ACC_ODR_100HZ;
-  this->accel_cfg_.range = BMI2_ACC_RANGE_2G;
-  this->accel_cfg_.bw = BMI2_ACC_NORMAL_AVG4;
-  this->accel_cfg_.perf_mode = BMI2_PERF_OPT_MODE;
-  rslt = bmi270_set_sensor_config(&this->accel_cfg_, 1, &this->sensor_);
-  if (rslt != BMI2_OK) {
-    ESP_LOGE(TAG, "Failed to configure accelerometer: %d", rslt);
-    this->mark_failed();
-    return;
+  // Enable accel, gyro, temperature
+  val = 0x0E;
+  this->write_register(REG_PWR_CTRL, &val, 1);
+  delay(50);
+
+  // Accel: ODR=100Hz, BWP=normal, perf mode, range=±2g → 16384 LSB/g
+  uint8_t acc_conf = 0xA8, acc_range = 0x00;
+  this->write_register(REG_ACC_CONF, &acc_conf, 1);
+  this->write_register(REG_ACC_RANGE, &acc_range, 1);
+  this->accel_sensitivity_ = 16384.0f;
+
+  // Gyro: ODR=100Hz, BWP=normal, perf mode, range=±2000 dps → 16.4 LSB/dps
+  uint8_t gyr_conf = 0xA8, gyr_range = 0x00;
+  this->write_register(REG_GYR_CONF, &gyr_conf, 1);
+  this->write_register(REG_GYR_RANGE, &gyr_range, 1);
+  this->gyro_sensitivity_ = 16.4f;
+
+  this->apply_power_save_mode();
+  this->sensors_active_ = true;
+  ESP_LOGI(TAG, "BMI270 setup complete");
+}
+
+bool BMI270Component::bmi270_init_config_file() {
+  // Disable advanced power save before writing config
+  uint8_t val = 0x00;
+  this->write_register(REG_PWR_CONF, &val, 1);
+  delay(1);
+
+  val = 0x00;
+  this->write_register(REG_INIT_CTRL, &val, 1);
+
+  const size_t config_len = sizeof(bmi270_config_file);
+  uint8_t chunk[32];
+  for (size_t i = 0; i < config_len; i += 32) {
+    uint16_t addr = (uint16_t)(i / 2);
+    uint8_t addr_lo = (uint8_t)(addr & 0xFF);
+    uint8_t addr_hi = (uint8_t)((addr >> 8) & 0xFF);
+    this->write_register(REG_INIT_ADDR_0, &addr_lo, 1);
+    this->write_register(REG_INIT_ADDR_1, &addr_hi, 1);
+
+    size_t chunk_size = std::min((size_t)32, config_len - i);
+    memcpy(chunk, bmi270_config_file + i, chunk_size);
+    this->write_register(REG_INIT_DATA, chunk, chunk_size);
   }
 
-  // Configure gyroscope
-  this->gyro_cfg_.odr = BMI2_GYR_ODR_100HZ;
-  this->gyro_cfg_.range = BMI2_GYR_RANGE_2000;
-  this->gyro_cfg_.bw = BMI2_GYR_NORMAL_MODE;
-  this->gyro_cfg_.noise_perf = BMI2_POWER_OPT_MODE;
-  this->gyro_cfg_.filter_perf = BMI2_PERF_OPT_MODE;
-  rslt = bmi270_set_sensor_config(&this->gyro_cfg_, 1, &this->sensor_);
-  if (rslt != BMI2_OK) {
-    ESP_LOGE(TAG, "Failed to configure gyroscope: %d", rslt);
-    this->mark_failed();
-    return;
+  val = 0x01;
+  this->write_register(REG_INIT_CTRL, &val, 1);
+  delay(20);
+
+  uint8_t status = 0;
+  if (this->read_register(REG_INTERNAL_STATUS, &status, 1) != i2c::ERROR_OK) {
+    ESP_LOGE(TAG, "Failed to read INTERNAL_STATUS");
+    return false;
+  }
+  if ((status & 0x0F) != 0x01) {
+    ESP_LOGE(TAG, "BMI270 init failed, INTERNAL_STATUS=0x%02X", status);
+    return false;
   }
 
-  this->is_initialized_ = true;
+  ESP_LOGI(TAG, "BMI270 config file loaded successfully");
+  return true;
+}
+
+void BMI270Component::apply_power_save_mode() {
+  uint8_t val = (this->power_save_mode_ == POWER_SAVE_MODE_LOW_POWER) ? 0x03 : 0x00;
+  this->write_register(REG_PWR_CONF, &val, 1);
 }
 
 void BMI270Component::update() {
-  if (!this->is_initialized_)
+  if (!this->sensors_active_)
     return;
 
-  struct bmi2_sensor_data sensor_data[2] = {};
-  sensor_data[0].type = BMI2_ACCEL;
-  sensor_data[1].type = BMI2_GYRO;
-
-  int8_t rslt = bmi2_get_sensor_data(sensor_data, 2, &this->sensor_);
-  if (rslt != BMI2_OK) {
-    ESP_LOGW(TAG, "Failed to read sensor data: %d", rslt);
+  // Read accel (0x0C–0x11) + gyro (0x12–0x17) in one burst: 12 bytes
+  uint8_t data[12];
+  if (this->read_register(REG_ACC_DATA, data, 12) != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Failed to read sensor data");
     return;
   }
 
-  if (this->accel_x_sensor_ != nullptr)
-    this->accel_x_sensor_->publish_state(sensor_data[0].sens_data.acc.x / 1000.0f);
-  if (this->accel_y_sensor_ != nullptr)
-    this->accel_y_sensor_->publish_state(sensor_data[0].sens_data.acc.y / 1000.0f);
-  if (this->accel_z_sensor_ != nullptr)
-    this->accel_z_sensor_->publish_state(sensor_data[0].sens_data.acc.z / 1000.0f);
+  auto raw = [&](int i) -> int16_t { return (int16_t)((data[i + 1] << 8) | data[i]); };
 
-  if (this->gyro_x_sensor_ != nullptr)
-    this->gyro_x_sensor_->publish_state(sensor_data[1].sens_data.gyr.x / 16.4f);
-  if (this->gyro_y_sensor_ != nullptr)
-    this->gyro_y_sensor_->publish_state(sensor_data[1].sens_data.gyr.y / 16.4f);
-  if (this->gyro_z_sensor_ != nullptr)
-    this->gyro_z_sensor_->publish_state(sensor_data[1].sens_data.gyr.z / 16.4f);
+  if (this->accel_x_sensor_) this->accel_x_sensor_->publish_state(raw(0) / this->accel_sensitivity_);
+  if (this->accel_y_sensor_) this->accel_y_sensor_->publish_state(raw(2) / this->accel_sensitivity_);
+  if (this->accel_z_sensor_) this->accel_z_sensor_->publish_state(raw(4) / this->accel_sensitivity_);
+  if (this->gyro_x_sensor_)  this->gyro_x_sensor_->publish_state(raw(6) / this->gyro_sensitivity_);
+  if (this->gyro_y_sensor_)  this->gyro_y_sensor_->publish_state(raw(8) / this->gyro_sensitivity_);
+  if (this->gyro_z_sensor_)  this->gyro_z_sensor_->publish_state(raw(10) / this->gyro_sensitivity_);
+
+  if (this->temperature_sensor_) {
+    uint8_t temp_data[2];
+    if (this->read_register(REG_TEMP_DATA, temp_data, 2) == i2c::ERROR_OK) {
+      int16_t raw_temp = (int16_t)((temp_data[1] << 8) | temp_data[0]);
+      this->temperature_sensor_->publish_state((raw_temp / 512.0f) + 23.0f);
+    }
+  }
 }
 
 void BMI270Component::dump_config() {
@@ -103,19 +154,7 @@ void BMI270Component::dump_config() {
   }
 }
 
-int8_t BMI270Component::read_bytes(uint8_t reg_addr, uint8_t *data, uint32_t len, void *intf_ptr) {
-  auto *dev = reinterpret_cast<esphome::i2c::I2CDevice *>(intf_ptr);
-  return dev->read(reg_addr, data, len) ? BMI2_OK : BMI2_E_COM_FAIL;
-}
-
-int8_t BMI270Component::write_bytes(uint8_t reg_addr, const uint8_t *data, uint32_t len, void *intf_ptr) {
-  auto *dev = reinterpret_cast<esphome::i2c::I2CDevice *>(intf_ptr);
-  return dev->write(reg_addr, data, len) ? BMI2_OK : BMI2_E_COM_FAIL;
-}
-
-void BMI270Component::delay_usec(uint32_t period, void *) {
-  delayMicroseconds(period);
-}
+float BMI270Component::get_setup_priority() const { return setup_priority::DATA; }
 
 }  // namespace bmi270
 }  // namespace esphome


### PR DESCRIPTION
## Summary

- Removes dependency on missing Bosch BMI2 SDK headers (`bmi2_dev`, `bmi270_init`, `BMI2_I2C_INTF`, etc.) that caused build failures on ESPHome 2026.x
- Rewrites `bmi270.cpp` to use ESPHome's native `read_register()` / `write_register()` I2C API
- Config file loading implemented via raw burst writes to `INIT_DATA` (0x5E)
- Sensor data read directly from registers `0x0C`–`0x17` in a single 12-byte burst
- Temperature reading from `0x22`–`0x23`
- Existing `bmi270.h` interface unchanged — no YAML config changes required

## Test plan

- [ ] Verify compilation on ESPHome 2026.3.0+ with ESP-IDF 5.5.x
- [ ] Confirm `INTERNAL_STATUS` returns `0x01` after config file load
- [ ] Confirm accel/gyro/temperature values publish correctly on M5Stack StickS3

Closes #9