### PR TITLE
feat(ed047tc1): add partial_update() to reduce e-ink panel wear

### DIFF
--- a/components/ed047tc1/ed047tc1.cpp
+++ b/components/ed047tc1/ed047tc1.cpp
@@ -1,11 +1,11 @@
 #include "ed047tc1.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
-#include "esphome/core/gpio.h" // For InternalGPIOPin
-#include <driver/gpio.h>       // For ESP-IDF's gpio_num_t
+#include "esphome/core/gpio.h"
+#include <driver/gpio.h>
 #include "esp_heap_caps.h"
-
-#include "output_lcd/lcd_driver.h" // For LcdEpdConfig_t
+#include "output_lcd/lcd_driver.h"
+#include <algorithm>
 
 namespace esphome {
 namespace ed047tc1 {
@@ -160,29 +160,45 @@ void ED047TC1Display::setup() {
     ESP_LOGCONFIG(TAG, "ED047TC1 setup finished.");
 }
 
+void ED047TC1Display::copy_buffer_to_epd_(int x, int y, int w, int h) {
+    if (!this->buffer_) return;
+    uint8_t *epd_fb = epd_hl_get_framebuffer(&this->hl_state_);
+    if (!epd_fb) return;
+    int screen_w = this->get_width_internal();
+    int x_end = std::min(x + w, screen_w);
+    int y_end = std::min(y + h, this->get_height_internal());
+    for (int py = y; py < y_end; py++) {
+        for (int px = x; px < x_end; px++) {
+            uint8_t pixel = this->buffer_[(py * screen_w) + px];
+            epd_draw_pixel(px, py, (pixel >> 4) << 4, epd_fb);
+        }
+    }
+}
+
 void ED047TC1Display::update() {
     this->do_update_();
     if (!this->buffer_) { ESP_LOGE(TAG, "ESPHome buffer null in update!"); return; }
-    uint8_t* epd_fb = epd_hl_get_framebuffer(&this->hl_state_);
-    if (!epd_fb) { ESP_LOGE(TAG, "EPDiy FB null in update!"); return; }
+    if (!epd_hl_get_framebuffer(&this->hl_state_)) { ESP_LOGE(TAG, "EPDiy FB null in update!"); return; }
 
-    ESP_LOGD(TAG, "Copying ESPHome buffer to EPDiy buffer and updating display...");
-    int w = this->get_width_internal();
-    int h = this->get_height_internal();
-    for (int y = 0; y < h; y++) {
-        for (int x = 0; x < w; x++) {
-            uint8_t esphome_pixel_8bpp = this->buffer_[(y * w) + x];
-            uint8_t epdiy_draw_value = (esphome_pixel_8bpp >> 4) << 4;
-            epd_draw_pixel(x, y, epdiy_draw_value, epd_fb);
-        }
-    }
-    ESP_LOGD(TAG, "Buffer copy complete. Triggering EPD screen update.");
+    copy_buffer_to_epd_(0, 0, get_width_internal(), get_height_internal());
+    ESP_LOGD(TAG, "Full update — MODE_GC16");
     epd_poweron();
-    EpdRect update_rect = epd_full_screen();
-    enum EpdDrawError draw_result = epd_hl_update_area(&this->hl_state_, MODE_GC16, epd_ambient_temperature(), update_rect);
-    if (draw_result != EPD_DRAW_SUCCESS) { ESP_LOGE(TAG, "epd_hl_update_area failed: %d", draw_result); }
+    EpdRect full = epd_full_screen();
+    enum EpdDrawError err = epd_hl_update_area(&this->hl_state_, MODE_GC16, epd_ambient_temperature(), full);
+    if (err != EPD_DRAW_SUCCESS) { ESP_LOGE(TAG, "update failed: %d", err); }
     epd_poweroff();
-    ESP_LOGD(TAG, "ED047TC1 update cycle finished.");
+}
+
+void ED047TC1Display::partial_update(int x, int y, int w, int h, enum EpdDrawMode mode) {
+    this->do_update_();
+    copy_buffer_to_epd_(x, y, w, h);
+    EpdRect area;
+    area.x = x; area.y = y; area.width = w; area.height = h;
+    ESP_LOGD(TAG, "partial_update mode=0x%02X (%d,%d,%d,%d)", mode, x, y, w, h);
+    epd_poweron();
+    enum EpdDrawError err = epd_hl_update_area(&this->hl_state_, mode, epd_ambient_temperature(), area);
+    if (err != EPD_DRAW_SUCCESS) { ESP_LOGE(TAG, "partial_update failed: %d", err); }
+    epd_poweroff();
 }
 
 void ED047TC1Display::draw_absolute_pixel_internal(int x, int y, Color color) {

--- a/components/ed047tc1/ed047tc1.h
+++ b/components/ed047tc1/ed047tc1.h
@@ -30,6 +30,8 @@ class ED047TC1Display : public display::DisplayBuffer {
   void dump_config() override;
   float get_setup_priority() const override { return esphome::setup_priority::HARDWARE; }
 
+  void partial_update(int x, int y, int w, int h, enum EpdDrawMode mode = MODE_GL16);
+
   void set_pwr_pin(GPIOPin *pwr_pin) { pwr_pin_ = pwr_pin; }
   void set_bst_en_pin(GPIOPin *bst_en_pin) { bst_en_pin_ = bst_en_pin; }
   void set_xstl_pin(GPIOPin *xstl_pin) { xstl_pin_ = xstl_pin; }
@@ -56,6 +58,7 @@ class ED047TC1Display : public display::DisplayBuffer {
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void copy_buffer_to_epd_(int x, int y, int w, int h);
   int get_width_internal() override { return EPD_WIDTH; }
   int get_height_internal() override { return EPD_HEIGHT; }
   int get_bpp() const { return 8; }


### PR DESCRIPTION
## Summary

- Adds `partial_update(x, y, w, h, mode=MODE_GL16)` for zone-specific refresh with selectable draw mode
- Extracts `copy_buffer_to_epd_(x, y, w, h)` helper to eliminate code duplication between `update()` and `partial_update()`
- `update()` behavior is **unchanged** — full screen, `MODE_GC16`

## Draw mode guide

| Mode | Flash | Grayscale | Wear | Recommended use |
|------|-------|-----------|------|-----------------|
| `MODE_GC16` | yes | 16 levels | high | Full refresh, ghosting cleanup |
| `MODE_GL16` | no | 16 levels | ~3x lower | Routine partial updates (default) |
| `MODE_DU` | no | B&W only | lowest | Animation |

## Usage example

```yaml
time:
  - platform: homeassistant
    on_time:
      - seconds: 0
        then:
          - lambda: |-
              id(my_display).partial_update(0, 0, 540, 560, MODE_GL16);

interval:
  - interval: 1h
    then:
      - component.update: my_display  # full GC16 to clear ghosting
```

## Test plan

- [ ] Confirm `partial_update()` refreshes only the specified region
- [ ] Confirm `update()` still does full screen GC16 refresh
- [ ] Confirm no regression on M5Stack PaperS3

Closes #10